### PR TITLE
AMDGPU/SI: Fix DS_WRITE2_B32 pattern

### DIFF
--- a/lib/Target/AMDGPU/DSInstructions.td
+++ b/lib/Target/AMDGPU/DSInstructions.td
@@ -521,8 +521,8 @@ def : DSWritePat <DS_WRITE_B64, v2i32, si_store_local_align8>;
 def : Pat <
   (si_store_local v2i32:$value, (DS64Bit4ByteAligned i32:$ptr, i8:$offset0,
                                                                i8:$offset1)),
-  (DS_WRITE2_B32 $ptr, (EXTRACT_SUBREG $value, sub0),
-                       (EXTRACT_SUBREG $value, sub1), $offset0, $offset1,
+  (DS_WRITE2_B32 $ptr, (i32 (EXTRACT_SUBREG $value, sub0)),
+                       (i32 (EXTRACT_SUBREG $value, sub1)), $offset0, $offset1,
                        (i1 0))
 >;
 


### PR DESCRIPTION
For some reason the return value of EXTRACT_SUBREG defaults to the smallest
register type.

Fixes:

LLVM :: CodeGen/AMDGPU/amdgpu.private-memory.ll
LLVM :: CodeGen/AMDGPU/ds-sub-offset.ll
LLVM :: CodeGen/AMDGPU/ds_write2.ll
LLVM :: CodeGen/AMDGPU/lds-alignment.ll
LLVM :: CodeGen/AMDGPU/llvm.memcpy.ll
LLVM :: CodeGen/AMDGPU/merge-stores.ll
LLVM :: CodeGen/AMDGPU/private-memory-atomics.ll
LLVM :: CodeGen/AMDGPU/promote-alloca-no-opts.ll
LLVM :: CodeGen/AMDGPU/reduce-store-width-alignment.ll
